### PR TITLE
Ported dsl_sat_spec from DSL.v to DSL2.v, proved transferFrom in DSL2.v satisfies its specs.

### DIFF
--- a/erc20/DSL2.v
+++ b/erc20/DSL2.v
@@ -45,8 +45,6 @@ Delimit Scope dsl_scope with dsl.
 
 Definition State := StateMonad.state state.
 
-Definition FE A B := @Coq.Logic.FunctionalExtensionality.functional_extensionality A B.
-
 Inductive Stmt :=
   DSL_require (cond: env -> message -> State bool)
 | DSL_emit (evt: env -> message -> State event)


### PR DESCRIPTION
Ported dsl_sat_spec from DSL.v to DSL2.v, proved transferFrom in DSL2.v satisfies its specs.